### PR TITLE
add zRam swap usage to memory page

### DIFF
--- a/harbour-lighthouse.pro
+++ b/harbour-lighthouse.pro
@@ -49,7 +49,8 @@ SOURCES += \
     src/monitor.cpp \
     src/lighthouse.cpp \
     src/battery.cpp \
-    src/languages.cpp
+    src/languages.cpp \
+    src/zram.cpp
 
 OTHER_FILES += \
     qml/cover/CoverPage.qml \
@@ -80,7 +81,8 @@ HEADERS += \
     src/process.h \
     src/monitor.h \
     src/battery.h \
-    src/languages.h
+    src/languages.h \
+    src/zram.h
 
 icon86.files += icons/86x86/harbour-lighthouse.png
 icon86.path = /usr/share/icons/hicolor/86x86/apps

--- a/qml/pages/Memory.qml
+++ b/qml/pages/Memory.qml
@@ -67,5 +67,24 @@ Page {
                 margins: Theme.paddingLarge
             }
         }
+        SectionHeader{
+            text: qsTr("zRam swap")
+        }
+
+        ProgressBar {
+            minimumValue: 0
+            maximumValue: zram.diskSize
+            value: zram.data
+            label: qsTr("%1 MiB from %2 MiB used (compression %3 %)")
+                        .arg(kiBToMiB(zram.data))
+                        .arg(kiBToMiB(zram.diskSize))
+                        .arg(zram.data == 0 ? "-" : Math.round((1-(zram.compressed / zram.data)) * 100))
+
+            anchors {
+                left: parent.left
+                right: parent.right
+                margins: Theme.paddingLarge
+            }
+        }
     }
 }

--- a/src/lighthouse.cpp
+++ b/src/lighthouse.cpp
@@ -31,6 +31,7 @@
 #include "monitor.h"
 #include "cpu.h"
 #include "memory.h"
+#include "zram.h"
 #include "process.h"
 #include "battery.h"
 
@@ -49,6 +50,7 @@ int main(int argc, char *argv[])
     CPU cpu;
     Process process;
     Memory memory;
+    Zram zram;
     Battery battery;
     QFileSystemWatcher appsWatch;
     appsWatch.addPath("/usr/share/applications");
@@ -61,6 +63,8 @@ int main(int argc, char *argv[])
                      &cpu, &CPU::setTemperature);
     QObject::connect(&monitor, &Monitor::memoryChanged,
                      &memory, &Memory::setMemory);
+    QObject::connect(&monitor, &Monitor::zramChanged,
+                     &zram, &Zram::onZramChanged);
     QObject::connect(&monitor, &Monitor::processChanged,
                      &process, &Process::setProcesses);
     QObject::connect(&monitor, &Monitor::processCountChanged,
@@ -80,6 +84,7 @@ int main(int argc, char *argv[])
     view->rootContext()->setContextProperty("languages", &languages);
     view->rootContext()->setContextProperty("cpu", &cpu);
     view->rootContext()->setContextProperty("memory", &memory);
+    view->rootContext()->setContextProperty("zram", &zram);
     view->rootContext()->setContextProperty("monitor", &monitor);
     view->rootContext()->setContextProperty("process", &process);
     view->rootContext()->setContextProperty("battery", &battery);

--- a/src/monitor.h
+++ b/src/monitor.h
@@ -87,6 +87,7 @@ namespace Lighthouse {
             void run() Q_DECL_OVERRIDE;
             void procCPUActivity();
             void procMemory();
+            void procZRam();
             void procBattery(const QString& fileName);
             void procProcessCount();
             pid_t getNextPID(QStringListIterator& iterator, int activePID);
@@ -103,6 +104,7 @@ namespace Lighthouse {
         signals:
             void CPUUsageChanged(const IntList& usage);
             void memoryChanged(unsigned long total, unsigned long free);
+            void zramChanged(qint64 disksize, qint64 data, qint64 compr);
             void intervalChanged(int interval);
             void pausedChanged(bool paused);
             void coverPageChanged(int page);

--- a/src/zram.cpp
+++ b/src/zram.cpp
@@ -1,0 +1,51 @@
+/*
+    Copyright (C) 2018 Lukáš Karas <lukas.karas@centrum.cz>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "zram.h"
+
+namespace Lighthouse {
+
+
+Zram::Zram(QObject *parent):
+    QObject(parent)
+{}
+
+qint64 Zram::getDiskSize() const
+{
+    return disksize;
+}
+
+qint64 Zram::getData() const
+{
+    return data;
+}
+
+qint64 Zram::getCompressed() const
+{
+    return compr;
+}
+
+
+void Zram::onZramChanged(qint64 disksize, qint64 data, qint64 compr)
+{
+    this->disksize = disksize;
+    this->data = data;
+    this->compr = compr;
+    emit zramChanged();
+}
+
+}

--- a/src/zram.h
+++ b/src/zram.h
@@ -1,0 +1,51 @@
+/*
+    Copyright (C) 2018 Lukáš Karas <lukas.karas@centrum.cz>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef ZRAM_H
+#define ZRAM_H
+
+#include <QObject>
+
+namespace Lighthouse {
+
+    class Zram : public QObject
+    {
+        Q_OBJECT
+        Q_PROPERTY(qint64 diskSize READ getDiskSize NOTIFY zramChanged)
+        Q_PROPERTY(qint64 data READ getData NOTIFY zramChanged)
+        Q_PROPERTY(qint64 compressed READ getCompressed NOTIFY zramChanged)
+    public:
+        explicit Zram(QObject *parent = 0);
+
+        qint64 getDiskSize() const;
+        qint64 getData() const;
+        qint64 getCompressed() const;
+
+    public slots:
+        void onZramChanged(qint64 disksize, qint64 data, qint64 compr);
+
+    signals:
+        void zramChanged();
+
+    private:
+        qint64 disksize{0};
+        qint64 data{0};
+        qint64 compr{0};
+    };
+}
+
+#endif // ZRAM_H

--- a/translations/harbour-lighthouse-ar.ts
+++ b/translations/harbour-lighthouse-ar.ts
@@ -164,46 +164,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="95"/>
+        <location filename="../src/monitor.cpp" line="96"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation>وحدة المعالجة المركزية</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation>الذاكرة</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation>البطارية</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation>غير معروف</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="120"/>
+        <location filename="../src/monitor.cpp" line="121"/>
         <source>CPU</source>
         <translation>وحدة المعالجة المركزية</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>Memory</source>
         <translation>الذاكرة</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Battery</source>
         <translation>البطارية</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation>غير معروف</translation>
@@ -228,6 +228,16 @@
     <message>
         <location filename="../qml/pages/Memory.qml" line="63"/>
         <source>%1 MiB free out of %2 MiB total</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="71"/>
+        <source>zRam swap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="78"/>
+        <source>%1 MiB from %2 MiB used (compression %3 %)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-lighthouse-cs.ts
+++ b/translations/harbour-lighthouse-cs.ts
@@ -164,46 +164,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="95"/>
+        <location filename="../src/monitor.cpp" line="96"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation>Procesor</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation>Paměť</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation>Baterie</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation>Neznámý</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="120"/>
+        <location filename="../src/monitor.cpp" line="121"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>Memory</source>
         <translation>Paměť</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Battery</source>
         <translation>Baterie</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation>Neznámý</translation>
@@ -229,6 +229,16 @@
         <location filename="../qml/pages/Memory.qml" line="63"/>
         <source>%1 MiB free out of %2 MiB total</source>
         <translation>%1 MiB volné z %2 MiB celkem</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="71"/>
+        <source>zRam swap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="78"/>
+        <source>%1 MiB from %2 MiB used (compression %3 %)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-lighthouse-da.ts
+++ b/translations/harbour-lighthouse-da.ts
@@ -164,46 +164,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="95"/>
+        <location filename="../src/monitor.cpp" line="96"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="120"/>
+        <location filename="../src/monitor.cpp" line="121"/>
         <source>CPU</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Battery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation type="unfinished"></translation>
@@ -228,6 +228,16 @@
     <message>
         <location filename="../qml/pages/Memory.qml" line="63"/>
         <source>%1 MiB free out of %2 MiB total</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="71"/>
+        <source>zRam swap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="78"/>
+        <source>%1 MiB from %2 MiB used (compression %3 %)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-lighthouse-de_CH.ts
+++ b/translations/harbour-lighthouse-de_CH.ts
@@ -164,46 +164,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="95"/>
+        <location filename="../src/monitor.cpp" line="96"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="120"/>
+        <location filename="../src/monitor.cpp" line="121"/>
         <source>CPU</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Battery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation type="unfinished"></translation>
@@ -228,6 +228,16 @@
     <message>
         <location filename="../qml/pages/Memory.qml" line="63"/>
         <source>%1 MiB free out of %2 MiB total</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="71"/>
+        <source>zRam swap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="78"/>
+        <source>%1 MiB from %2 MiB used (compression %3 %)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-lighthouse-de_DE.ts
+++ b/translations/harbour-lighthouse-de_DE.ts
@@ -165,46 +165,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="95"/>
+        <location filename="../src/monitor.cpp" line="96"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation>Speicher</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation>Batterie</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation>Unbekannt</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="120"/>
+        <location filename="../src/monitor.cpp" line="121"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>Memory</source>
         <translation>Speicher</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Battery</source>
         <translation>Batterie</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation>Unbekannt</translation>
@@ -229,6 +229,16 @@
     <message>
         <location filename="../qml/pages/Memory.qml" line="63"/>
         <source>%1 MiB free out of %2 MiB total</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="71"/>
+        <source>zRam swap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="78"/>
+        <source>%1 MiB from %2 MiB used (compression %3 %)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-lighthouse-el.ts
+++ b/translations/harbour-lighthouse-el.ts
@@ -164,46 +164,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="95"/>
+        <location filename="../src/monitor.cpp" line="96"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="120"/>
+        <location filename="../src/monitor.cpp" line="121"/>
         <source>CPU</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Battery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation type="unfinished"></translation>
@@ -228,6 +228,16 @@
     <message>
         <location filename="../qml/pages/Memory.qml" line="63"/>
         <source>%1 MiB free out of %2 MiB total</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="71"/>
+        <source>zRam swap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="78"/>
+        <source>%1 MiB from %2 MiB used (compression %3 %)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-lighthouse-en.ts
+++ b/translations/harbour-lighthouse-en.ts
@@ -164,46 +164,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="95"/>
+        <location filename="../src/monitor.cpp" line="96"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation>cpu</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation>memory</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation>battery</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation>unknown</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="120"/>
+        <location filename="../src/monitor.cpp" line="121"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>Memory</source>
         <translation>Memory</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Battery</source>
         <translation>Battery</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation>Unknown</translation>
@@ -228,6 +228,16 @@
     <message>
         <location filename="../qml/pages/Memory.qml" line="63"/>
         <source>%1 MiB free out of %2 MiB total</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="71"/>
+        <source>zRam swap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="78"/>
+        <source>%1 MiB from %2 MiB used (compression %3 %)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-lighthouse-es.ts
+++ b/translations/harbour-lighthouse-es.ts
@@ -164,46 +164,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="95"/>
+        <location filename="../src/monitor.cpp" line="96"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation>procesador</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation>memoria</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation>batería</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation>desconocido</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="120"/>
+        <location filename="../src/monitor.cpp" line="121"/>
         <source>CPU</source>
         <translation>Procesador</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>Memory</source>
         <translation>Memoria</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Battery</source>
         <translation>Batería</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation>Desconocido</translation>
@@ -228,6 +228,16 @@
     <message>
         <location filename="../qml/pages/Memory.qml" line="63"/>
         <source>%1 MiB free out of %2 MiB total</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="71"/>
+        <source>zRam swap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="78"/>
+        <source>%1 MiB from %2 MiB used (compression %3 %)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-lighthouse-es_AR.ts
+++ b/translations/harbour-lighthouse-es_AR.ts
@@ -164,46 +164,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="95"/>
+        <location filename="../src/monitor.cpp" line="96"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation>cpu</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation>memoria</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation>batería</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="120"/>
+        <location filename="../src/monitor.cpp" line="121"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>Memory</source>
         <translation>Memoria</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Battery</source>
         <translation>Batería</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation type="unfinished">Desconocida</translation>
@@ -228,6 +228,16 @@
     <message>
         <location filename="../qml/pages/Memory.qml" line="63"/>
         <source>%1 MiB free out of %2 MiB total</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="71"/>
+        <source>zRam swap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="78"/>
+        <source>%1 MiB from %2 MiB used (compression %3 %)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-lighthouse-fi_FI.ts
+++ b/translations/harbour-lighthouse-fi_FI.ts
@@ -164,46 +164,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="95"/>
+        <location filename="../src/monitor.cpp" line="96"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="120"/>
+        <location filename="../src/monitor.cpp" line="121"/>
         <source>CPU</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Battery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation type="unfinished"></translation>
@@ -228,6 +228,16 @@
     <message>
         <location filename="../qml/pages/Memory.qml" line="63"/>
         <source>%1 MiB free out of %2 MiB total</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="71"/>
+        <source>zRam swap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="78"/>
+        <source>%1 MiB from %2 MiB used (compression %3 %)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-lighthouse-fr.ts
+++ b/translations/harbour-lighthouse-fr.ts
@@ -164,46 +164,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="95"/>
+        <location filename="../src/monitor.cpp" line="96"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation>cpu</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation>mémoire</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation>batterie</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation>inconnu</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="120"/>
+        <location filename="../src/monitor.cpp" line="121"/>
         <source>CPU</source>
         <translation>Processeur</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>Memory</source>
         <translation>Mémoire</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Battery</source>
         <translation>Batterie</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation>Inconnu</translation>
@@ -228,6 +228,16 @@
     <message>
         <location filename="../qml/pages/Memory.qml" line="63"/>
         <source>%1 MiB free out of %2 MiB total</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="71"/>
+        <source>zRam swap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="78"/>
+        <source>%1 MiB from %2 MiB used (compression %3 %)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-lighthouse-gl.ts
+++ b/translations/harbour-lighthouse-gl.ts
@@ -164,46 +164,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="95"/>
+        <location filename="../src/monitor.cpp" line="96"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation>cpu</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation>memoria</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation>bateria</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation>descoñecido</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="120"/>
+        <location filename="../src/monitor.cpp" line="121"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>Memory</source>
         <translation>Memoria</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Battery</source>
         <translation>Bateria</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation>Descoñecido</translation>
@@ -228,6 +228,16 @@
     <message>
         <location filename="../qml/pages/Memory.qml" line="63"/>
         <source>%1 MiB free out of %2 MiB total</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="71"/>
+        <source>zRam swap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="78"/>
+        <source>%1 MiB from %2 MiB used (compression %3 %)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-lighthouse-hu.ts
+++ b/translations/harbour-lighthouse-hu.ts
@@ -164,46 +164,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="95"/>
+        <location filename="../src/monitor.cpp" line="96"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation>cpu</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation>memória</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation>akkumulátor</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation>ismeretlen</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="120"/>
+        <location filename="../src/monitor.cpp" line="121"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>Memory</source>
         <translation>Memória</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Battery</source>
         <translation>Akkumulátor</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation>Ismeretlen</translation>
@@ -228,6 +228,16 @@
     <message>
         <location filename="../qml/pages/Memory.qml" line="63"/>
         <source>%1 MiB free out of %2 MiB total</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="71"/>
+        <source>zRam swap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="78"/>
+        <source>%1 MiB from %2 MiB used (compression %3 %)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-lighthouse-it.ts
+++ b/translations/harbour-lighthouse-it.ts
@@ -164,46 +164,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="95"/>
+        <location filename="../src/monitor.cpp" line="96"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation>cpu</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation>memoria</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation>batteria</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation>sconosciuto</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="120"/>
+        <location filename="../src/monitor.cpp" line="121"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>Memory</source>
         <translation>Memoria</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Battery</source>
         <translation>Batteria</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation>Sconosciuto</translation>
@@ -228,6 +228,16 @@
     <message>
         <location filename="../qml/pages/Memory.qml" line="63"/>
         <source>%1 MiB free out of %2 MiB total</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="71"/>
+        <source>zRam swap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="78"/>
+        <source>%1 MiB from %2 MiB used (compression %3 %)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-lighthouse-nb.ts
+++ b/translations/harbour-lighthouse-nb.ts
@@ -164,46 +164,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="95"/>
+        <location filename="../src/monitor.cpp" line="96"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation>cpu</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation>minne</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation>batteri</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation>ukjent</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="120"/>
+        <location filename="../src/monitor.cpp" line="121"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>Memory</source>
         <translation>Minne</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Battery</source>
         <translation>Batteri</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation>Ukjent</translation>
@@ -228,6 +228,16 @@
     <message>
         <location filename="../qml/pages/Memory.qml" line="63"/>
         <source>%1 MiB free out of %2 MiB total</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="71"/>
+        <source>zRam swap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="78"/>
+        <source>%1 MiB from %2 MiB used (compression %3 %)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-lighthouse-nl.ts
+++ b/translations/harbour-lighthouse-nl.ts
@@ -164,46 +164,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="95"/>
+        <location filename="../src/monitor.cpp" line="96"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation>cpu</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation>geheugen</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation>batterij</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation>onbekend</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="120"/>
+        <location filename="../src/monitor.cpp" line="121"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>Memory</source>
         <translation>Geheugen</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Battery</source>
         <translation>Batterij</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation>Onbekend</translation>
@@ -228,6 +228,16 @@
     <message>
         <location filename="../qml/pages/Memory.qml" line="63"/>
         <source>%1 MiB free out of %2 MiB total</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="71"/>
+        <source>zRam swap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="78"/>
+        <source>%1 MiB from %2 MiB used (compression %3 %)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-lighthouse-pl.ts
+++ b/translations/harbour-lighthouse-pl.ts
@@ -164,46 +164,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="95"/>
+        <location filename="../src/monitor.cpp" line="96"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation>procesor</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation>pamięć</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation>bateria</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation>nieznane</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="120"/>
+        <location filename="../src/monitor.cpp" line="121"/>
         <source>CPU</source>
         <translation>Procesor</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>Memory</source>
         <translation>Pamięć</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Battery</source>
         <translation>Bateria</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation>Nieznane</translation>
@@ -228,6 +228,16 @@
     <message>
         <location filename="../qml/pages/Memory.qml" line="63"/>
         <source>%1 MiB free out of %2 MiB total</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="71"/>
+        <source>zRam swap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="78"/>
+        <source>%1 MiB from %2 MiB used (compression %3 %)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-lighthouse-ru.ts
+++ b/translations/harbour-lighthouse-ru.ts
@@ -164,46 +164,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="95"/>
+        <location filename="../src/monitor.cpp" line="96"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation>процессор</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation>память</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation>батарея</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation>неизвестный</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="120"/>
+        <location filename="../src/monitor.cpp" line="121"/>
         <source>CPU</source>
         <translation>Процессор</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>Memory</source>
         <translation>Память</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Battery</source>
         <translation>Батарея</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation>Неизвестный</translation>
@@ -228,6 +228,16 @@
     <message>
         <location filename="../qml/pages/Memory.qml" line="63"/>
         <source>%1 MiB free out of %2 MiB total</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="71"/>
+        <source>zRam swap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="78"/>
+        <source>%1 MiB from %2 MiB used (compression %3 %)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-lighthouse-sr.ts
+++ b/translations/harbour-lighthouse-sr.ts
@@ -164,46 +164,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="95"/>
+        <location filename="../src/monitor.cpp" line="96"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="120"/>
+        <location filename="../src/monitor.cpp" line="121"/>
         <source>CPU</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Battery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation type="unfinished"></translation>
@@ -228,6 +228,16 @@
     <message>
         <location filename="../qml/pages/Memory.qml" line="63"/>
         <source>%1 MiB free out of %2 MiB total</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="71"/>
+        <source>zRam swap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="78"/>
+        <source>%1 MiB from %2 MiB used (compression %3 %)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-lighthouse-sv.ts
+++ b/translations/harbour-lighthouse-sv.ts
@@ -164,46 +164,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="95"/>
+        <location filename="../src/monitor.cpp" line="96"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation>cpu</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation>minne</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation>batteri</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation>okänt</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="120"/>
+        <location filename="../src/monitor.cpp" line="121"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>Memory</source>
         <translation>Minne</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Battery</source>
         <translation>Batteri</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation>Okänt</translation>
@@ -228,6 +228,16 @@
     <message>
         <location filename="../qml/pages/Memory.qml" line="63"/>
         <source>%1 MiB free out of %2 MiB total</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="71"/>
+        <source>zRam swap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="78"/>
+        <source>%1 MiB from %2 MiB used (compression %3 %)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-lighthouse-tr.ts
+++ b/translations/harbour-lighthouse-tr.ts
@@ -164,46 +164,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="95"/>
+        <location filename="../src/monitor.cpp" line="96"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="120"/>
+        <location filename="../src/monitor.cpp" line="121"/>
         <source>CPU</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Battery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation type="unfinished"></translation>
@@ -228,6 +228,16 @@
     <message>
         <location filename="../qml/pages/Memory.qml" line="63"/>
         <source>%1 MiB free out of %2 MiB total</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="71"/>
+        <source>zRam swap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="78"/>
+        <source>%1 MiB from %2 MiB used (compression %3 %)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-lighthouse-zh_CN.ts
+++ b/translations/harbour-lighthouse-zh_CN.ts
@@ -164,46 +164,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="95"/>
+        <location filename="../src/monitor.cpp" line="96"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation>cpu</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation>内存</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation>电池</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation>未知</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="120"/>
+        <location filename="../src/monitor.cpp" line="121"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>Memory</source>
         <translation>内存</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Battery</source>
         <translation>电池</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation>未知</translation>
@@ -228,6 +228,16 @@
     <message>
         <location filename="../qml/pages/Memory.qml" line="63"/>
         <source>%1 MiB free out of %2 MiB total</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="71"/>
+        <source>zRam swap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="78"/>
+        <source>%1 MiB from %2 MiB used (compression %3 %)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-lighthouse-zh_TW.ts
+++ b/translations/harbour-lighthouse-zh_TW.ts
@@ -164,46 +164,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="95"/>
+        <location filename="../src/monitor.cpp" line="96"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation>cpu</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation>記憶體</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation>電池</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation>未知</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="120"/>
+        <location filename="../src/monitor.cpp" line="121"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>Memory</source>
         <translation>記憶體</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Battery</source>
         <translation>電池</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation>未知</translation>
@@ -228,6 +228,16 @@
     <message>
         <location filename="../qml/pages/Memory.qml" line="63"/>
         <source>%1 MiB free out of %2 MiB total</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="71"/>
+        <source>zRam swap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="78"/>
+        <source>%1 MiB from %2 MiB used (compression %3 %)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-lighthouse.ts
+++ b/translations/harbour-lighthouse.ts
@@ -164,46 +164,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="95"/>
+        <location filename="../src/monitor.cpp" line="96"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="120"/>
+        <location filename="../src/monitor.cpp" line="121"/>
         <source>CPU</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Battery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation type="unfinished"></translation>
@@ -228,6 +228,16 @@
     <message>
         <location filename="../qml/pages/Memory.qml" line="63"/>
         <source>%1 MiB free out of %2 MiB total</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="71"/>
+        <source>zRam swap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/Memory.qml" line="78"/>
+        <source>%1 MiB from %2 MiB used (compression %3 %)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
Hi. 

I think that that status of zRam is useful information and should be part of memory overview :-)


![screenshot_20181102_001](https://user-images.githubusercontent.com/309458/47903659-46392680-de84-11e8-8b7d-fb4284b5abb5.png)
