### PR TITLE
Add missing dependencies for OBS build and Chum metadata

### DIFF
--- a/rpm/harbour-lighthouse.spec
+++ b/rpm/harbour-lighthouse.spec
@@ -16,7 +16,7 @@ Summary:    Lighthouse System Monitor
 Version:    1.6.5
 Release:    1
 Group:      Qt/Qt
-License:    LICENSE
+License:    GPLv3
 URL:        https://github.com/almindor/lighthouse
 Source0:    %{name}-%{version}.tar.bz2
 Requires:   sailfishsilica-qt5 >= 0.10.9
@@ -31,6 +31,16 @@ BuildRequires:  qt5-qttools-linguist
 %description
 Sailfish OS system monitor for system and per-processor CPU, memory usages with additional phone controls.
 
+%if "%{?vendor}" == "chum"
+PackageName: Lighthouse
+Type: desktop-application
+Categories:
+ - System
+ - Utility
+Custom:
+  Repo: https://github.com/almindor/lighthouse
+Icon: https://raw.githubusercontent.com/almindor/lighthouse/master/svg/icon-lighthouse.svg
+%endif
 
 %prep
 %setup -q -n %{name}-%{version}

--- a/rpm/harbour-lighthouse.spec
+++ b/rpm/harbour-lighthouse.spec
@@ -23,8 +23,10 @@ Requires:   sailfishsilica-qt5 >= 0.10.9
 BuildRequires:  pkgconfig(Qt5Quick)
 BuildRequires:  pkgconfig(Qt5Qml)
 BuildRequires:  pkgconfig(Qt5Core)
+BuildRequires:  pkgconfig(Qt5DBus)
 BuildRequires:  pkgconfig(sailfishapp) >= 0.0.10
 BuildRequires:  desktop-file-utils
+BuildRequires:  qt5-qttools-linguist
 
 %description
 Sailfish OS system monitor for system and per-processor CPU, memory usages with additional phone controls.


### PR DESCRIPTION
This PR adds dependencies that were missing for OBS builds. Namely, SDK preinstalls more than OBS and it is frequent when packages are missing few when trying to build at OBS.

Next, I have added also Chum metadata section to SPEC description. This will allow us to add Lighthouse to Chum repos. As a result, you would be able to fix #27 and #11 as Chum builds binaries for full range of SFOS platforms and long list of its versions.

Please review.