### PR TITLE
explicitly disable sandboxing

### DIFF
--- a/harbour-lighthouse.desktop
+++ b/harbour-lighthouse.desktop
@@ -5,3 +5,5 @@ Name=Lighthouse
 Icon=harbour-lighthouse
 Exec=harbour-lighthouse
 
+[X-Sailjail]
+Sandboxing=Disabled


### PR DESCRIPTION
Sailfish OS 4.4 enable sandboxing for all applications by default.
But Lighthouse cannot work in sandbox.
For that reason, it is necessary to explicitly disable sandboxing.