### PR TITLE
Restore Android apps to Applications view

### DIFF
--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -22,6 +22,7 @@
 #include <QStringList>
 #include <QDir>
 #include <QProcess>
+#include <QStandardPaths>
 
 namespace Lighthouse {
 //    const int CPU_FLAGS_ACTIVE = 1;
@@ -158,7 +159,9 @@ namespace Lighthouse {
     }
 
     void Monitor::run() {
-        updateApplicationMap("/usr/share/applications");
+        for (const QString &location : QStandardPaths::standardLocations(QStandardPaths::ApplicationsLocation)) {
+            updateApplicationMap(location);
+        }
         procProcessorCount();
         fCPUActiveTicks.resize(fCPUCount + 1); // room for "total"
         fCPUTotalTicks.resize(fCPUCount + 1); // room for "total"
@@ -417,8 +420,7 @@ namespace Lighthouse {
         }
     }
 
-    void Monitor::updateAppName(const QString& fileName) {
-        const QString fullName = "/usr/share/applications/" + fileName;
+    void Monitor::updateAppName(const QString& fileName, const QString& fullName) {
         if ( !QFile::exists(fullName) ) {
             qWarning() << "File not found: " << fullName << "\n";
             return;
@@ -445,17 +447,16 @@ namespace Lighthouse {
     }
 
     void Monitor::updateApplicationMap(const QString& path) {
-        QDir apps(path); // "/usr/share/applications"
+        QDir apps(path); // any launcher directory
         QStringList filters;
         filters << "*.desktop";
         apps.setNameFilters(filters);
 
         const QStringList files = apps.entryList();
         QStringListIterator iterator(files);
-        fAppNameMap.clear();
         while ( iterator.hasNext() ) {
             const QString& fileName = iterator.next();
-            updateAppName(fileName);
+            updateAppName(fileName, apps.filePath(fileName));
         }
     }
 

--- a/src/monitor.h
+++ b/src/monitor.h
@@ -97,7 +97,7 @@ namespace Lighthouse {
             void procTemperature();
             void procProcessorCount();
             void fillProcMap(ProcMap& procMap, IntList* deletes);
-            void updateAppName(const QString& fileName);
+            void updateAppName(const QString& fileName, const QString& fullName);
             int getInterval() const;
         public slots:
             void updateApplicationMap(const QString& path);

--- a/translations/harbour-lighthouse-ar.ts
+++ b/translations/harbour-lighthouse-ar.ts
@@ -162,46 +162,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation>وحدة المعالجة المركزية</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation>الذاكرة</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation>البطارية</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="99"/>
+        <location filename="../src/monitor.cpp" line="100"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation>غير معروف</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>CPU</source>
         <translation>وحدة المعالجة المركزية</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Memory</source>
         <translation>الذاكرة</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Battery</source>
         <translation>البطارية</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="124"/>
+        <location filename="../src/monitor.cpp" line="125"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation>غير معروف</translation>

--- a/translations/harbour-lighthouse-cs.ts
+++ b/translations/harbour-lighthouse-cs.ts
@@ -162,46 +162,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation>Procesor</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation>Paměť</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation>Baterie</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="99"/>
+        <location filename="../src/monitor.cpp" line="100"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation>Neznámý</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Memory</source>
         <translation>Paměť</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Battery</source>
         <translation>Baterie</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="124"/>
+        <location filename="../src/monitor.cpp" line="125"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation>Neznámý</translation>

--- a/translations/harbour-lighthouse-da.ts
+++ b/translations/harbour-lighthouse-da.ts
@@ -162,46 +162,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="99"/>
+        <location filename="../src/monitor.cpp" line="100"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>CPU</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Battery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="124"/>
+        <location filename="../src/monitor.cpp" line="125"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation type="unfinished"></translation>

--- a/translations/harbour-lighthouse-de_CH.ts
+++ b/translations/harbour-lighthouse-de_CH.ts
@@ -162,46 +162,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="99"/>
+        <location filename="../src/monitor.cpp" line="100"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>CPU</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Battery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="124"/>
+        <location filename="../src/monitor.cpp" line="125"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation type="unfinished"></translation>

--- a/translations/harbour-lighthouse-de_DE.ts
+++ b/translations/harbour-lighthouse-de_DE.ts
@@ -162,46 +162,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation>Speicher</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation>Batterie</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="99"/>
+        <location filename="../src/monitor.cpp" line="100"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation>Unbekannt</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Memory</source>
         <translation>Speicher</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Battery</source>
         <translation>Batterie</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="124"/>
+        <location filename="../src/monitor.cpp" line="125"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation>Unbekannt</translation>

--- a/translations/harbour-lighthouse-el.ts
+++ b/translations/harbour-lighthouse-el.ts
@@ -162,46 +162,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="99"/>
+        <location filename="../src/monitor.cpp" line="100"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>CPU</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Battery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="124"/>
+        <location filename="../src/monitor.cpp" line="125"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation type="unfinished"></translation>

--- a/translations/harbour-lighthouse-en.ts
+++ b/translations/harbour-lighthouse-en.ts
@@ -162,46 +162,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation>cpu</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation>memory</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation>battery</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="99"/>
+        <location filename="../src/monitor.cpp" line="100"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation>unknown</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Memory</source>
         <translation>Memory</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Battery</source>
         <translation>Battery</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="124"/>
+        <location filename="../src/monitor.cpp" line="125"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation>Unknown</translation>

--- a/translations/harbour-lighthouse-es.ts
+++ b/translations/harbour-lighthouse-es.ts
@@ -162,46 +162,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation>procesador</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation>memoria</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation>batería</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="99"/>
+        <location filename="../src/monitor.cpp" line="100"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation>desconocido</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>CPU</source>
         <translation>Procesador</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Memory</source>
         <translation>Memoria</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Battery</source>
         <translation>Batería</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="124"/>
+        <location filename="../src/monitor.cpp" line="125"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation>Desconocido</translation>

--- a/translations/harbour-lighthouse-es_AR.ts
+++ b/translations/harbour-lighthouse-es_AR.ts
@@ -162,46 +162,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation>cpu</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation>memoria</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation>batería</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="99"/>
+        <location filename="../src/monitor.cpp" line="100"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Memory</source>
         <translation>Memoria</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Battery</source>
         <translation>Batería</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="124"/>
+        <location filename="../src/monitor.cpp" line="125"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation type="unfinished">Desconocida</translation>

--- a/translations/harbour-lighthouse-fi_FI.ts
+++ b/translations/harbour-lighthouse-fi_FI.ts
@@ -162,46 +162,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="99"/>
+        <location filename="../src/monitor.cpp" line="100"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>CPU</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Battery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="124"/>
+        <location filename="../src/monitor.cpp" line="125"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation type="unfinished"></translation>

--- a/translations/harbour-lighthouse-fr.ts
+++ b/translations/harbour-lighthouse-fr.ts
@@ -162,46 +162,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation>cpu</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation>mémoire</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation>batterie</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="99"/>
+        <location filename="../src/monitor.cpp" line="100"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation>inconnu</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>CPU</source>
         <translation>Processeur</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Memory</source>
         <translation>Mémoire</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Battery</source>
         <translation>Batterie</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="124"/>
+        <location filename="../src/monitor.cpp" line="125"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation>Inconnu</translation>

--- a/translations/harbour-lighthouse-gl.ts
+++ b/translations/harbour-lighthouse-gl.ts
@@ -162,46 +162,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation>cpu</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation>memoria</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation>bateria</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="99"/>
+        <location filename="../src/monitor.cpp" line="100"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation>descoñecido</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Memory</source>
         <translation>Memoria</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Battery</source>
         <translation>Bateria</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="124"/>
+        <location filename="../src/monitor.cpp" line="125"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation>Descoñecido</translation>

--- a/translations/harbour-lighthouse-hu.ts
+++ b/translations/harbour-lighthouse-hu.ts
@@ -162,46 +162,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation>cpu</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation>memória</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation>akkumulátor</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="99"/>
+        <location filename="../src/monitor.cpp" line="100"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation>ismeretlen</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Memory</source>
         <translation>Memória</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Battery</source>
         <translation>Akkumulátor</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="124"/>
+        <location filename="../src/monitor.cpp" line="125"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation>Ismeretlen</translation>

--- a/translations/harbour-lighthouse-it.ts
+++ b/translations/harbour-lighthouse-it.ts
@@ -162,46 +162,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation>cpu</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation>memoria</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation>batteria</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="99"/>
+        <location filename="../src/monitor.cpp" line="100"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation>sconosciuto</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Memory</source>
         <translation>Memoria</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Battery</source>
         <translation>Batteria</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="124"/>
+        <location filename="../src/monitor.cpp" line="125"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation>Sconosciuto</translation>

--- a/translations/harbour-lighthouse-nb.ts
+++ b/translations/harbour-lighthouse-nb.ts
@@ -162,46 +162,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation>cpu</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation>minne</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation>batteri</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="99"/>
+        <location filename="../src/monitor.cpp" line="100"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation>ukjent</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Memory</source>
         <translation>Minne</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Battery</source>
         <translation>Batteri</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="124"/>
+        <location filename="../src/monitor.cpp" line="125"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation>Ukjent</translation>

--- a/translations/harbour-lighthouse-nl.ts
+++ b/translations/harbour-lighthouse-nl.ts
@@ -162,46 +162,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation>cpu</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation>geheugen</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation>batterij</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="99"/>
+        <location filename="../src/monitor.cpp" line="100"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation>onbekend</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Memory</source>
         <translation>Geheugen</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Battery</source>
         <translation>Batterij</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="124"/>
+        <location filename="../src/monitor.cpp" line="125"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation>Onbekend</translation>

--- a/translations/harbour-lighthouse-pl.ts
+++ b/translations/harbour-lighthouse-pl.ts
@@ -162,46 +162,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation>procesor</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation>pamięć</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation>bateria</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="99"/>
+        <location filename="../src/monitor.cpp" line="100"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation>nieznane</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>CPU</source>
         <translation>Procesor</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Memory</source>
         <translation>Pamięć</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Battery</source>
         <translation>Bateria</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="124"/>
+        <location filename="../src/monitor.cpp" line="125"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation>Nieznane</translation>

--- a/translations/harbour-lighthouse-ru.ts
+++ b/translations/harbour-lighthouse-ru.ts
@@ -162,46 +162,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation>процессор</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation>память</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation>батарея</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="99"/>
+        <location filename="../src/monitor.cpp" line="100"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation>неизвестный</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>CPU</source>
         <translation>Процессор</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Memory</source>
         <translation>Память</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Battery</source>
         <translation>Батарея</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="124"/>
+        <location filename="../src/monitor.cpp" line="125"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation>Неизвестный</translation>

--- a/translations/harbour-lighthouse-sr.ts
+++ b/translations/harbour-lighthouse-sr.ts
@@ -162,46 +162,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="99"/>
+        <location filename="../src/monitor.cpp" line="100"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>CPU</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Battery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="124"/>
+        <location filename="../src/monitor.cpp" line="125"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation type="unfinished"></translation>

--- a/translations/harbour-lighthouse-sv.ts
+++ b/translations/harbour-lighthouse-sv.ts
@@ -162,46 +162,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation>cpu</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation>minne</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation>batteri</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="99"/>
+        <location filename="../src/monitor.cpp" line="100"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation>okänt</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Memory</source>
         <translation>Minne</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Battery</source>
         <translation>Batteri</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="124"/>
+        <location filename="../src/monitor.cpp" line="125"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation>Okänt</translation>

--- a/translations/harbour-lighthouse-tr.ts
+++ b/translations/harbour-lighthouse-tr.ts
@@ -162,46 +162,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="99"/>
+        <location filename="../src/monitor.cpp" line="100"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>CPU</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Battery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="124"/>
+        <location filename="../src/monitor.cpp" line="125"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation type="unfinished"></translation>

--- a/translations/harbour-lighthouse-zh_CN.ts
+++ b/translations/harbour-lighthouse-zh_CN.ts
@@ -162,46 +162,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation>cpu</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation>内存</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation>电池</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="99"/>
+        <location filename="../src/monitor.cpp" line="100"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation>未知</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Memory</source>
         <translation>内存</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Battery</source>
         <translation>电池</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="124"/>
+        <location filename="../src/monitor.cpp" line="125"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation>未知</translation>

--- a/translations/harbour-lighthouse-zh_TW.ts
+++ b/translations/harbour-lighthouse-zh_TW.ts
@@ -162,46 +162,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation>cpu</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation>記憶體</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation>電池</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="99"/>
+        <location filename="../src/monitor.cpp" line="100"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation>未知</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Memory</source>
         <translation>記憶體</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Battery</source>
         <translation>電池</translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="124"/>
+        <location filename="../src/monitor.cpp" line="125"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation>未知</translation>

--- a/translations/harbour-lighthouse.ts
+++ b/translations/harbour-lighthouse.ts
@@ -162,46 +162,46 @@
 <context>
     <name>Lighthouse::Monitor</name>
     <message>
-        <location filename="../src/monitor.cpp" line="96"/>
+        <location filename="../src/monitor.cpp" line="97"/>
         <source>cpu</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="97"/>
+        <location filename="../src/monitor.cpp" line="98"/>
         <source>memory</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="98"/>
+        <location filename="../src/monitor.cpp" line="99"/>
         <source>battery</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="99"/>
+        <location filename="../src/monitor.cpp" line="100"/>
         <source>unknown</source>
         <comment>cover label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="121"/>
+        <location filename="../src/monitor.cpp" line="122"/>
         <source>CPU</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="122"/>
+        <location filename="../src/monitor.cpp" line="123"/>
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="123"/>
+        <location filename="../src/monitor.cpp" line="124"/>
         <source>Battery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/monitor.cpp" line="124"/>
+        <location filename="../src/monitor.cpp" line="125"/>
         <source>Unknown</source>
         <comment>Cover label in summary page</comment>
         <translation type="unfinished"></translation>


### PR DESCRIPTION
Recently Android app launchers have moved to ~/.local/share/applications so aren't picked up for the 'Applications' filter. I've changed the monitor here to iterate over all QStandardPaths::ApplicationsLocations instead, so all launchers should be picked up now. I removed the fAppNameMap.clear() so updateApplicationMap can be called multiple times, as I don't think Monitor::run is called more than once anyway?